### PR TITLE
Create utf-8 html output (and fix a typo)

### DIFF
--- a/private/html.rkt
+++ b/private/html.rkt
@@ -62,6 +62,7 @@
   (define %age (get-percentages/file path covered?))
   `(html ()
     (head ()
+          (meta ([charset "utf-8"]))
           (link ([rel "stylesheet"] [type "text/css"] [href ,path-to-css])))
     (body ()
           ,@(%s->xexprs %age)

--- a/raco.rkt
+++ b/raco.rkt
@@ -42,7 +42,7 @@
   (printf "generating test coverage for ~s\n" files)
   (define passed (apply test-files! files))
   (define coverage (remove-dirs (get-test-coverage) exclude-dirs))
-  (printf "dumbing coverage info into ~s\n" coverage-dir)
+  (printf "dumping coverage info into ~s\n" coverage-dir)
   (generate-coverage coverage coverage-dir)
   (exit
    (case passed


### PR DESCRIPTION
This adds a `<meta charset="utf-8">` tag to the HTML output to tell browsers to use utf-8, even when displaying the file locally. Without this, special characters, notably `λ`, get interpreted as ASCII and get garbled.

I also fixed a small typo in the `raco cover` output.