### PR TITLE
Command line args (Fix #36)

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require "cover.rkt" "format.rkt" "private/contracts.rkt" "private/format-utils.rkt"
          "private/raw.rkt" racket/contract)
+
 (provide
  (contract-out
   [coverage/c contract?]
@@ -8,8 +9,9 @@
   [test-files! (->* () (#:submod symbol?)
                     #:rest
                     (listof (or/c path-string?
-                                  (list/c path-string? (vectorof string?
-                                                                 #:immutable #t))))
+                                  (list/c path-string?
+                                          (and/c (lambda (v) (not (impersonator? v)))
+                                                 (vectorof string? #:immutable #t)))))
                     any)]
   [clear-coverage! (-> any)]
   [get-test-coverage (-> coverage/c)]

--- a/main.rkt
+++ b/main.rkt
@@ -6,11 +6,10 @@
   [coverage/c contract?]
   [file-coverage/c contract?]
   [test-files! (->* () (#:submod symbol?)
-                    #:rest (listof path-string?)
-                    ;; TODO when we figure out the contract issue we will change this
-                    #;
+                    #:rest
                     (listof (or/c path-string?
-                                  (list/c path-string? (vectorof string?))))
+                                  (list/c path-string? (vectorof string?
+                                                                 #:immutable #t))))
                     any)]
   [clear-coverage! (-> any)]
   [get-test-coverage (-> coverage/c)]

--- a/raco.rkt
+++ b/raco.rkt
@@ -4,11 +4,10 @@
          racket/match
          racket/contract/base
          racket/function
-         "cover.rkt"
+         "main.rkt"
          (only-in "private/contracts.rkt" coverage-gen/c)
          "private/shared.rkt"
          "private/file-utils.rkt"
-         "private/format-utils.rkt"
          (only-in (submod compiler/commands/test paths) collection-paths)
          pkg/lib)
 
@@ -139,7 +138,7 @@
         null
         (map (lambda (x)
                (list (->absolute (car x))
-                     (list->vector (cadr x))))
+                     (vector->immutable-vector (list->vector (cadr x)))))
              new-argv)))
   (define full-argv (append expanded-argv args))
   (if (should-omit? (current-directory) full-omits)

--- a/scribblings/api.scrbl
+++ b/scribblings/api.scrbl
@@ -26,12 +26,19 @@ removed during macro expansion and are thus neither run or not run.
 Note that the @racket[srcloc]s are one indexed, meaning a @racket[1]
 represents the first character in the file.}
 
-@defproc[(test-files! (#:submod submod symbol? 'test) (files path-string?) ...) any]{
+@defproc[(test-files! (#:submod submod symbol? 'test)
+                      (files (or/c path-string?
+                                  (list/c path-string
+                                          (and/c (negate impersonator?)
+                                                 (vectorof string? #:immutable #t))))) ...)
+                      any]{
 
-Runs all given @racket[files] and their submodule @racket[submod] (if it exists), storing the coverage information.
-The function returns false if any tests fail.
-Test coverage information is still collected when test fail.
-Test coverage info is added to existing coverage info.}
+Runs all given @racket[files] and their submodule @racket[submod] (if it exists), storing the
+coverage information.  If the path is paired with a vector then that vector is used as the
+@racket[current-command-line-arguments] when executing that file. This vector must be immuatable and
+not wrapped by a @racket[chaperone] or @racket[impersonator]. The function returns false if any
+tests fail.  Test coverage information is still collected when test fail.  Test coverage info is
+added to existing coverage info.}
 
 @defproc[(clear-coverage!) any]{Clears all coverage information.}
 


### PR DESCRIPTION
The crux of this is we force the vector to not already be impersonated (which includes chaperones) and then force the vector to be checked with a flat contract, thus avoiding *any* wrapping of the vector.