### PR TITLE
fixed a dynamic-require/macro-providing issue

### DIFF
--- a/cover.rkt
+++ b/cover.rkt
@@ -76,7 +76,7 @@ in "coverage.rkt". This raw coverage information is converted to a usable form b
 ;; evaluate the current module in the current namespace
 (define (run-mod to-run)
   (vprintf "running ~s\n" to-run)
-  (eval `(dynamic-require ',to-run #f))
+  (eval `(dynamic-require ',to-run 0))
   (vprintf "finished running ~s\n" to-run))
 
 ;; [Listof Path] -> Loader Compiler

--- a/tests/do-syntax.rkt
+++ b/tests/do-syntax.rkt
@@ -1,0 +1,15 @@
+#lang racket
+(require cover rackunit racket/runtime-path)
+(define-runtime-path syntax.rkt "syntax.rkt")
+(test-begin
+ (after
+  (clear-coverage!)
+  (test-files! syntax.rkt)
+  (define x (get-test-coverage))
+  (define c?
+    (make-covered? (hash-ref x (path->string syntax.rkt))
+                   (path->string syntax.rkt)))
+  (for ([i (in-naturals 1)]
+        [_ (in-string (file->string syntax.rkt))])
+    (check-not-eq? (c? i) 'uncovered (~a i)))
+  (clear-coverage!)))

--- a/tests/syntax.rkt
+++ b/tests/syntax.rkt
@@ -1,0 +1,31 @@
+#lang racket
+;; These tests modified from https://github.com/jackfirth/point-free
+(provide define/compose
+         arg-count
+         define/arg-count)
+
+(define-syntax-rule (define/compose id f ...)
+  (define id (compose f ...)))
+
+(define-syntax-rule (arg-count n expr)
+  (lambda args
+    (let ([n (length args)])
+      (apply expr args))))
+
+(define-syntax-rule (define/arg-count id n expr)
+  (define id (arg-count n expr)))
+
+(module+ test
+  (require rackunit)
+  (define-binary-check (check-syntax-datum stx-actual stx-expected)
+    (equal? (syntax->datum stx-actual)
+            (syntax->datum stx-expected)))
+  (check-syntax-datum (expand-once #'(arg-count n identity))
+                      #'(lambda args (let ([n (length args)]) (apply identity args))))
+  (check-syntax-datum (expand-once #'(define/arg-count num-args n identity))
+                      #'(define num-args (arg-count n identity)))
+  (define num-args1
+    (arg-count n (const n)))
+  (check-eqv? (num-args1 0 0) 2)
+  (define/arg-count num-args2 n (const n))
+  (check-eqv? (num-args2 'foo 'bar 'baz) 3))


### PR DESCRIPTION
Previously modules that provided macros would have erroneous behavior in their coverage reports (or would crash the coverage report all together).