### PR TITLE
Switch to logging in instrumentation

### DIFF
--- a/coverage.rkt
+++ b/coverage.rkt
@@ -1,4 +1,0 @@
-(module coverage '#%kernel
-  (#%provide coverage cover-name)
-  (define-values (cover-name) (quote-syntax coverage))
-  (define-values (coverage) (make-hash)))

--- a/info.rkt
+++ b/info.rkt
@@ -13,7 +13,7 @@
 (define scribblings '(("scribblings/cover.scrbl" (multi-page))))
 
 (define test-omit-paths (list "tests/error-file.rkt" "scribblings"))
-(define cover-omit-paths (list "coverage.rkt"))
+(define cover-omit-paths (list "tests/nested.rkt"))
 
 (define cover-formats '(("html" cover generate-html-coverage)
                         ("coveralls" cover generate-coveralls-coverage)
@@ -21,4 +21,4 @@
 
 (define test-command-line-arguments '(("tests/arg.rkt" ("a"))))
 
-(define version "2.0.1")
+(define version "2.0.2")

--- a/private/coveralls.rkt
+++ b/private/coveralls.rkt
@@ -83,21 +83,20 @@
 
 (module+ test
   (test-begin
-   (parameterize ([current-directory root])
-     (after
-      (define file (path->string (simplify-path tests/prog.rkt)))
-      (test-files! (path->string (simplify-path tests/prog.rkt)))
-      (define coverage (get-test-coverage))
-      (define report
-        (with-env ("COVERALLS_REPO_TOKEN" "abc")
-          (generate-coveralls-report coverage (list (->absolute file)))))
-      (check-equal?
-       (hash-ref report 'source_files)
-       (list (hasheq 'source (file->string tests/prog.rkt)
-                             'coverage (line-coverage coverage file)
-                             'name "tests/prog.rkt")))
-      (check-equal? (hash-ref report 'repo_token) "abc")
-      (clear-coverage!)))))
+   (parameterize ([current-directory root]
+                  [current-cover-environment (make-cover-environment)])
+     (define file (path->string (simplify-path tests/prog.rkt)))
+     (test-files! (path->string (simplify-path tests/prog.rkt)))
+     (define coverage (get-test-coverage))
+     (define report
+       (with-env ("COVERALLS_REPO_TOKEN" "abc")
+         (generate-coveralls-report coverage (list (->absolute file)))))
+     (check-equal?
+      (hash-ref report 'source_files)
+      (list (hasheq 'source (file->string tests/prog.rkt)
+                    'coverage (line-coverage coverage file)
+                    'name "tests/prog.rkt")))
+     (check-equal? (hash-ref report 'repo_token) "abc"))))
 
 ;; -> [Hasheq String String
 ;; Determine the type of build (e.g. repo token, travis, etc) and return the appropriate metadata
@@ -139,18 +138,17 @@
 
 (module+ test
   (test-begin
-   (parameterize ([current-directory root])
-     (after
-      (define file (path->string (simplify-path tests/prog.rkt)))
-      (test-files! (path->string (simplify-path tests/prog.rkt)))
-      (define coverage (get-test-coverage))
-      (check-equal?
-       (generate-source-files coverage (list file))
-       (hasheq 'source_files
-               (list (hasheq 'source (file->string tests/prog.rkt)
-                             'coverage (line-coverage coverage file)
-                             'name "tests/prog.rkt"))))
-      (clear-coverage!)))))
+   (parameterize ([current-directory root]
+                  [current-cover-environment (make-cover-environment)])
+     (define file (path->string (simplify-path tests/prog.rkt)))
+     (test-files! (path->string (simplify-path tests/prog.rkt)))
+     (define coverage (get-test-coverage))
+     (check-equal?
+      (generate-source-files coverage (list file))
+      (hasheq 'source_files
+              (list (hasheq 'source (file->string tests/prog.rkt)
+                            'coverage (line-coverage coverage file)
+                            'name "tests/prog.rkt")))))))
 
 ;; CoverallsCoverage = Nat | json-null
 
@@ -181,10 +179,10 @@
 (module+ test
   (define-runtime-path path "../tests/basic/not-run.rkt")
   (let ()
-    (define file (path->string (simplify-path path)))
-    (test-files! file)
-    (check-equal? (line-coverage (get-test-coverage) file) '(1 0))
-    (clear-coverage!)))
+    (parameterize ([current-cover-environment (make-cover-environment)])
+      (define file (path->string (simplify-path path)))
+      (test-files! file)
+      (check-equal? (line-coverage (get-test-coverage) file) '(1 0)))))
 
 (define (hash-merge h1 h2) (for/fold ([res h1]) ([(k v) h2]) (hash-set res k v)))
 

--- a/private/shared.rkt
+++ b/private/shared.rkt
@@ -1,6 +1,11 @@
 #lang racket/base
-(provide verbose vprintf)
+(provide verbose vprintf
+         logger-init-message
+         logger-covered-message)
 (define verbose (make-parameter #f))
+
+(define logger-init-message "init")
+(define logger-covered-message "covered")
 
 ;; like printf but only in verbose mode
 (define o (current-output-port))

--- a/tests/do-eval.rkt
+++ b/tests/do-eval.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
 (require racket/runtime-path "../main.rkt" rackunit)
 (define-runtime-path eval.rkt "eval.rkt")
-(check-true (test-files! eval.rkt))
-(clear-coverage!)
+(parameterize ([current-cover-environment (make-cover-environment)])
+  (check-true (test-files! eval.rkt)))

--- a/tests/do-exit.rkt
+++ b/tests/do-exit.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
 (require "../main.rkt" racket/runtime-path)
 (define-runtime-path exit.rkt "exit.rkt")
-(test-files! exit.rkt)
-(clear-coverage!)
+(parameterize ([current-cover-environment (make-cover-environment)])
+  (test-files! exit.rkt))

--- a/tests/do-syntax.rkt
+++ b/tests/do-syntax.rkt
@@ -2,13 +2,11 @@
 (require cover rackunit racket/runtime-path)
 (define-runtime-path syntax.rkt "syntax.rkt")
 (test-begin
- (after
-  (clear-coverage!)
+ (parameterize ([current-cover-environment (make-cover-environment)])
   (test-files! syntax.rkt)
   (define x (get-test-coverage))
   (define c?
     (curry x (path->string syntax.rkt)))
   (for ([i (in-naturals 1)]
         [_ (in-string (file->string syntax.rkt))])
-    (check-not-eq? (c? i) 'uncovered (~a i)))
-  (clear-coverage!)))
+    (check-not-eq? (c? i) 'uncovered (~a i)))))

--- a/tests/error-file.rkt
+++ b/tests/error-file.rkt
@@ -1,4 +1,5 @@
 #lang racket
 (require rackunit)
 (check-true #f)
-(error "this is supposed to happend")
+(test-begin
+ (error "this is supposed to happend"))

--- a/tests/error.rkt
+++ b/tests/error.rkt
@@ -4,12 +4,12 @@
 (define-runtime-path error "error-file.rkt")
 (define-runtime-path main "main.rkt")
 (test-begin
- (after
+ (parameterize ([current-cover-environment (make-cover-environment)])
   (define (do-test files)
     (parameterize ([current-cover-environment (make-cover-environment)])
       (define o (open-output-string))
       (parameterize ([current-error-port o])
-        (apply test-files! files))
+        (check-false (apply test-files! files)))
       (define s (get-output-string o))
       (define c (get-test-coverage))
       (define covered (hash-keys (coverage-wrapper-map c)))
@@ -18,5 +18,4 @@
        files)))
   (define files (map path->string (list error main)))
   (do-test files)
-  (do-test (reverse files))
-  (clear-coverage!)))
+  (do-test (reverse files))))

--- a/tests/nested.rkt
+++ b/tests/nested.rkt
@@ -1,0 +1,34 @@
+#lang racket
+(require rackunit cover racket/runtime-path
+         "../private/file-utils.rkt")
+
+(define-runtime-path prog "basic/prog.rkt")
+(define-runtime-path cov "../cover.rkt")
+(define-runtime-path other "simple-multi/2.rkt")
+
+(define (do-test . files)
+  (define key (->absolute (first files)))
+  (void
+   (parameterize ([current-cover-environment (make-cover-environment)])
+     (check-true (apply test-files! files))
+     (parameterize ([current-cover-environment (make-cover-environment)])
+       (parameterize ([current-cover-environment (make-cover-environment)])
+         (check-true (apply test-files! files))
+         ((get-test-coverage) key 1))
+       (check-true (apply test-files! files))
+       ((get-test-coverage) key 1))
+     ((get-test-coverage) key 1))))
+
+
+;; these tests are logically "check-not-exn"s but that obsures inner test failures
+(test-case
+ "Prog nested coverage"
+ (do-test prog))
+
+(test-case
+ "Cover nested coverage"
+ (do-test cov))
+
+(test-case
+ "Cover nested coverage with many files"
+ (do-test cov other))

--- a/tests/provide.rkt
+++ b/tests/provide.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+(provide test
+         (struct-out tt))
+(define test 5)
+(struct tt (a b c) #:transparent)

--- a/tests/use-provide.rkt
+++ b/tests/use-provide.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(require (for-syntax "provide.rkt"))
+(begin-for-syntax (tt 1 2 3))


### PR DESCRIPTION
Fixes #79 #77 and #59

Roughly this commit switches the instrumentation mechanism to use
logging instead of a global hash table. This allows cover to work
across phases, and means that cover no longer needs to lift definitions
at compile time, fixing some submodule bugs.