### PR TITLE
Use `syntax-source-file-name` from `syntax/location`

### DIFF
--- a/cover.rkt
+++ b/cover.rkt
@@ -21,7 +21,7 @@ information is converted to a usable form by `get-test-coverage`.
          syntax/modread
          syntax/modresolve
          syntax/parse
-         unstable/syntax
+         syntax/location
          racket/bool
          racket/runtime-path
          racket/match

--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang setup/infotab
 (define name "cover")
 (define collection "cover")
-(define deps '(("base" #:version "6.1.1") "errortrace-lib" "rackunit-lib"
+(define deps '(("base" #:version "6.2.900.6") "errortrace-lib" "rackunit-lib"
                "syntax-color-lib" "compiler-lib"))
 (define build-deps
   '("racket-doc" "scribble-lib" "typed-racket-doc" "htdp-lib"


### PR DESCRIPTION
That binding is provided by `syntax/location` as of 6.2.900.6, and `unstable/syntax` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-lib` package, as it will not be part of the main distribution in future versions.
