### PR TITLE
Fix for issue #92 (HTML: Word-wrap puts all the line numbers before the whole code)

### DIFF
--- a/cover/private/html/assets/main.css
+++ b/cover/private/html/assets/main.css
@@ -1,4 +1,5 @@
 .code {
+  display: table;
   font-family: "Lucida Console", Monaco, monospace;
 }
 
@@ -53,12 +54,16 @@ div.report-container {
 }
 
 div.line-numbers {
-  display: inline-block;
+  display: table-cell;
   margin-right: 1em;
 }
 
 div.file-lines {
-  display: inline-block;
+  display: table-cell;
+}
+
+div.lines-wrapper {
+  display: table-row;
 }
 
 /* Sorting Triangles */

--- a/cover/private/html/assets/main.css
+++ b/cover/private/html/assets/main.css
@@ -56,6 +56,7 @@ div.report-container {
 div.line-numbers {
   display: table-cell;
   margin-right: 1em;
+  text-align: right;
 }
 
 div.file-lines {

--- a/cover/private/html/html.rkt
+++ b/cover/private/html/html.rkt
@@ -145,7 +145,7 @@
 (define (file->html path covered?)
   (define file (file->string path))
   (define lines (string-split file "\n"))
-  `(div ()
+  `(div ([class "lines-wrapper"])
         ,(div:line-numbers (length lines))
         ,(div:file-lines lines covered?)))
 

--- a/cover/private/html/html.rkt
+++ b/cover/private/html/html.rkt
@@ -157,7 +157,7 @@
      (define covered? (curry (get-test-coverage) f))
      (define lines (string-split (file->string f) "\n"))
      (check-equal? (file->html f covered?)
-                   `(div ()
+                   `(div ([class "lines-wrapper"])
                      ,(div:line-numbers (length lines))
                      ,(div:file-lines lines covered?))))))
 


### PR DESCRIPTION
* Fixes https://github.com/florence/cover/issues/92 .
* Right-aligned line numbers (in a separate commit, so you should be able to discard it if you prefer them left-aligned).

Travis-CI build failed, but it's due to a problem when downloading coveralls I think (`curl: (22) The requested URL returned error: 422` when downloading it).