### PR TITLE
Allow multiple output formats, by specifying `f` several times

### DIFF
--- a/cover/cover.rkt
+++ b/cover/cover.rkt
@@ -96,9 +96,9 @@ Thus, In essence this module has three responsibilites:
             (compile-file f))
           (for*/fold ([tests-failed #f])
                      ([f (in-list abs)]
-                      [submod-name (in-list (if (symbol? submod-names)
-                                                (list submod-names)
-                                                submod-names))])
+                      [submod-name (in-list (if (list? submod-names)
+                                                submod-names
+                                                (list submod-names)))])
             (printf "cover: running file: ~a\n" f)
             (define failed? (handle-file f submod-name))
             (or failed? tests-failed)))))

--- a/cover/scribblings/basics.scrbl
+++ b/cover/scribblings/basics.scrbl
@@ -11,8 +11,8 @@ exists). It will then dump the coverage information into a directory, by default
 The @exec{raco cover} command accepts the following flags:
 
 @itemize[@item{@Flag{f} or @DFlag{format}
-               --- Sets the coverage output type. This flag defaults to html.
-               valid formats are:
+               --- Sets the coverage output type. Can be included more than once.
+               This flag defaults to html. Valid formats are:
                @itemize[@item{html: Generates one html file per tested file.}]
                Other packages may install new formats. See @secref{plugin}}
          @item{@Flag{b} or @DFlag{exclude-pkg-basics}


### PR DESCRIPTION
Use-case:

```
raco cover -f html -f coveralls file.rkt
```

Note that I didn't add a test for that case, but since the only two output formats I know of are html and coveralls, it doesn't seem like to make much sense to run coveralls on a test file, does it?