### PR TITLE
Fixes relative links in HTML output

### DIFF
--- a/cover/private/html/html.rkt
+++ b/cover/private/html/html.rkt
@@ -73,7 +73,7 @@
                [p (in-list file-list)])
       (values k
               (path->string
-               (apply build-path (rest (explode-path (first p))))))))
+               (find-relative-path dir (first p))))))
   (define index (generate-index coverage files file/path-mapping))
   (cons (list (build-path dir "index.html") dir index)
         file-list))


### PR DESCRIPTION
When the destination directory has more than one path component, e.g. raco cover -d foo/coverage file.rkt, the URLs were of the form coverage/coverage/file.html . Also, when the -d option was a relative path starting with ./, e.g. ./foo/coverage, the URL in the links was an absolute path, like /home/user/project/foo/coverage/file.html, which doesn't work if the generated HTML is put online.

This patch fixes both cases (foo/coverage, and ./foo/coverage, I also tested with just ".", it works).