### PR TITLE
Implements GH issue #114 Allow for linking to line numbers in HTML output

### DIFF
--- a/cover/private/html/assets/main.css
+++ b/cover/private/html/assets/main.css
@@ -38,7 +38,7 @@ td a, td a:visited {
   color: #07A;
 }
 
-tr.stripe {
+tr.stripe, :target {
   background-color: #F5F5EC;
 }
 
@@ -57,6 +57,16 @@ div.line-numbers {
   display: table-cell;
   padding-right: 1em;
   text-align: right;
+}
+
+.line-numbers a {
+  color: black;
+  text-decoration: none;
+}
+
+.line-numbers a:hover {
+  color: blue;
+  text-decoration: underline;
 }
 
 div.file-lines {


### PR DESCRIPTION
The line given in the anchor has a grey brackground. It's done just using CSS, so:

* If we remember the sort order by changing the anchor will need to also color the line, since the :target selector won't work anymore
* Due to the way line numbers are made (a column div with all line numbers inside, and another div with all line text inside), just the line text is colored, not the line number.