### PR TITLE
cover-lib/cover/raco.rkt: fix flag spelling - quiqt -> quiet

### DIFF
--- a/cover-lib/cover/raco.rkt
+++ b/cover-lib/cover/raco.rkt
@@ -81,7 +81,7 @@
      [("-v" "--verbose")
       "Verbose mode"
       (set! noise 'verbose)]
-     [("-Q" "--quiqt")
+     [("-Q" "--quiet")
       "quiet mode"
       (set! noise 'quiet)]
      #:args (file . files)


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@gentoo.org>