### PR TITLE
Use colorblind-friendly colors to differentiate covered/uncovered

### DIFF
--- a/cover-lib/cover/private/html/assets/main.css
+++ b/cover-lib/cover/private/html/assets/main.css
@@ -3,12 +3,14 @@
   font-family: "Lucida Console", Monaco, monospace;
 }
 
+/* Colorblind-friendly colors taken from the Wong palette.
+See: https://docs.racket-lang.org/colorblind-palette/index.html */
 .uncovered {
-  color:red;
+  color:#D55E00;
 }
 
 .covered {
-  color:green;
+  color:#009E73;
 }
 
 .total-coverage {


### PR DESCRIPTION
These are the closest colors to the original red/green (chosen with the help of @dzoep who has normal color vision), selected from the Wong palette.

More information and palettes are at:
https://davidmathlogic.com/colorblind

Context: [Qi's Release Practices](https://github.com/drym-org/qi/wiki/Qi-Meeting-May-10-2024#qis-release-practices)
